### PR TITLE
Skip binlog and slowlog

### DIFF
--- a/ourdump
+++ b/ourdump
@@ -161,7 +161,7 @@ close $logwh;
 
 if (!$restorelog) {
     print 'SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;'."\n";
-    print 'SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n";
+    print 'SET @OLD_LONG_QUERY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n";
 }
 
 my $unlock=0;
@@ -180,7 +180,7 @@ my $exit_code = $?;
 
 if (!$restorelog) {
     print 'SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;'."\n";
-    print 'SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;'."\n";
+    print 'SET LONG_QUERY_TIME=@OLD_LONG_QUERY_TIME;'."\n";
 }
 
 if ( $exit_code != 0 ) {

--- a/ourdump
+++ b/ourdump
@@ -118,7 +118,6 @@ my $slave_status = get_slave_status($dbh);
 _log("[MASTER STATUS] $master_status");
 _log("[SLAVE STATUS] $slave_status") if defined $slave_status;
 _log("[START] mysqldump --databases " . join(" ", @databases));
-
 pipe my $logrh, my $logwh
     or die "Died: failed to create pipe:$!";
 my $pid = fork;
@@ -158,6 +157,10 @@ elsif ( $pid == 0 ) {
 
 #parent
 close $logwh;
+
+print 'SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;'."\n"
+print 'SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n"
+
 my $unlock=0;
 while(<$logrh>){
     print;
@@ -171,6 +174,9 @@ close $logrh;
 
 while (wait == -1) {}
 my $exit_code = $?;
+
+print 'SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;'."\n"
+print 'SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;'."\n"
 
 if ( $exit_code != 0 ) {
     _log("Error: mysqldump exited with code: %d", $exit_code >> 8);

--- a/ourdump
+++ b/ourdump
@@ -160,8 +160,8 @@ elsif ( $pid == 0 ) {
 close $logwh;
 
 if (!$restorelog) {
-    print 'SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;'."\n"
-    print 'SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n"
+    print 'SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;'."\n";
+    print 'SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n";
 }
 
 my $unlock=0;
@@ -179,8 +179,8 @@ while (wait == -1) {}
 my $exit_code = $?;
 
 if (!$restorelog) {
-    print 'SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;'."\n"
-    print 'SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;'."\n"
+    print 'SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;'."\n";
+    print 'SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;'."\n";
 }
 
 if ( $exit_code != 0 ) {

--- a/ourdump
+++ b/ourdump
@@ -69,6 +69,7 @@ GetOptions(
     "password=s" => \my $password,
     "h|help" => \my $help,
     "t|table" => \my $table,
+    "restorelog" => \my $restorelog,
 );
 
 if ( $help ) {
@@ -158,8 +159,10 @@ elsif ( $pid == 0 ) {
 #parent
 close $logwh;
 
-print 'SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;'."\n"
-print 'SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n"
+if (!$restorelog) {
+    print 'SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;'."\n"
+    print 'SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;'."\n"
+}
 
 my $unlock=0;
 while(<$logrh>){
@@ -175,8 +178,10 @@ close $logrh;
 while (wait == -1) {}
 my $exit_code = $?;
 
-print 'SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;'."\n"
-print 'SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;'."\n"
+if (!$restorelog) {
+    print 'SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;'."\n"
+    print 'SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;'."\n"
+}
 
 if ( $exit_code != 0 ) {
     _log("Error: mysqldump exited with code: %d", $exit_code >> 8);


### PR DESCRIPTION

```
-- [2020-01-21T15:23:44] ourdump start
-- [2020-01-21T15:23:44] Done "FLUSH TABLES WITH READ LOCK"
-- [2020-01-21T15:23:44] [MASTER STATUS] -- Could not get master status. Maybe binlog was disabled
-- [2020-01-21T15:23:44] [START] mysqldump --databases isucari
SET @OLD_SQL_LOG_BIN=@@SQL_LOG_BIN, SQL_LOG_BIN=0;
SET @OLD_LONG_QUEY_TIME=@@LONG_QUERY_TIME, LONG_QUERY_TIME=3306;
-- MySQL dump 10.13  Distrib 5.7.23, for macos10.13 (x86_64)
..
```

..

```
/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

-- Dump completed on 2020-01-21 15:24:20
SET SQL_LOG_BIN=@OLD_SQL_LOG_BIN;
SET LONG_QUEY_TIME=@OLD_LONG_QUEY_TIME;
-- [2020-01-21T15:24:20] ourdump ended 
```
